### PR TITLE
Make it more useable for real world applications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 nimcache
 /test
-
+*.html
 *.exe

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 nimcache
 /test
+
+*.exe

--- a/interfaced.nim
+++ b/interfaced.nim
@@ -48,8 +48,9 @@ macro implementInterface(interfaceName: typed, exports: static[bool]) : untyped 
     let
       methodName = identDefs[0]
       params = identDefs[1][0]
+      thisParameter = params[1][0]
       lambdaBody = nnkPar.newTree quote do:
-        `methodName`(cast[var T](this))
+        `methodName`(cast[var T](`thisParameter`))
       
     for i in 2 ..< len(params):
       let param = params[i]

--- a/interfaced.nim
+++ b/interfaced.nim
@@ -15,18 +15,13 @@ macro implementInterface(interfaceName: typed) : untyped =
       params = identDefs[1][0]
       lambdaBody = quote do:
         cast[var T](this).`methodName`()
-      call = lambdaBody[0]
 
     for i in 2 ..< len(params):
       let param = params[i]
       param.expectKind(nnkIdentDefs)
       for j in 0 .. len(param) - 3:
-        call.add param[j]
-
-    # leave out () when not needed
-    if call.len == 1:
-      lambdaBody[0] = call[0]
-
+        lambdaBody.add param[j]
+    
     methodName.expectKind nnkIdent
 
     objectConstructor.add nnkExprColonExpr.newTree(

--- a/interfaced.nimble
+++ b/interfaced.nimble
@@ -4,7 +4,7 @@ version       = "0.1.0"
 author        = "Andrea Ferretti"
 description   = "Go-like interfaces"
 license       = "Apache2"
-skipFiles     = @["test.nim"]
+skipFiles     = @["test.nim", "test_exports.nim", "test_logsink.nim"]
 
 # Dependencies
 

--- a/test.nim
+++ b/test.nim
@@ -1,5 +1,7 @@
 import interfaced
 
+import test_exports
+
 type
   Human = object
     name: string
@@ -23,7 +25,7 @@ createInterface(Animal):
   proc makeNoise(this: Animal): string
   proc legs(this: Animal): int
   proc greet(this: Animal, other: string): string
-
+    
 proc interact(animal: Animal) =
   echo animal.makeNoise
   echo animal.greet("James Bond")
@@ -37,7 +39,12 @@ when isMainModule:
     me = Human(name: "Andrea")
     bau = Dog()
 
-  for animal in @[me.toAnimal, bau.toAnimal]:
-    echo "Number of legs: ", legs(animal)
+    charmander = Charmander()
+    espeon = Espeon()
 
-  interactAll(me, bau)
+  for animal in @[me.toAnimal, bau.toAnimal, charmander.toAnimal, espeon.toAnimal]:
+    echo "Number of legs: ", legs(animal)
+  for pokemon in @[charmander.toPokemon, espeon.toPokemon]:
+    echo pokemon.name(), " is a ", pokemon.typ(), " Pokemon"
+
+  interactAll(me, bau, charmander, espeon)

--- a/test_exports.nim
+++ b/test_exports.nim
@@ -1,11 +1,11 @@
 import interfaced
 
 type
-    PokemonType* {.pure.} = enum
-        Fire, Psychic # ...
+  PokemonType* {.pure.} = enum
+    Fire, Psychic # ...
 
-    Charmander* = object
-    Espeon* = object
+  Charmander* = object
+  Espeon* = object
 
 proc makeNoise*(this: Charmander): string = "Charmander, Charmander"
 proc legs*(this: Charmander): int = 2
@@ -15,12 +15,19 @@ proc makeNoise*(this: Espeon): string = "By using Telepathy I'm able to communic
 proc legs*(this: Espeon): int = 4
 proc greet*(this: Espeon, other: string): string = "What a pleasure to meet you, " & other
 
-createInterface *Pokemon:
-    proc name*(this: Pokemon): string
-    proc typ*(this: Pokemon): PokemonType
+createInterface *Pokemon: # the * has to come before the name, due to limitations in Nim's lexer(as far as I know)
+  proc name*(this: Pokemon): string # the visibility of each method is set individually
+  proc typ*(this: Pokemon): PokemonType
 
 proc name*(this: Espeon): string = "Espeon"
 proc typ*(this: Espeon): PokemonType = PokemonType.Psychic
 
 proc name*(this: Charmander): string = "Charmander"
 proc typ*(this: Charmander): PokemonType = PokemonType.Fire
+
+createInterface *LogSink:
+  proc log*(this: LogSink, msg: string)
+  proc messagesWritten(this: LogSink): int
+
+proc echoSinkState*(sink: LogSink) =
+  echo sink.messagesWritten()

--- a/test_exports.nim
+++ b/test_exports.nim
@@ -1,0 +1,26 @@
+import interfaced
+
+type
+    PokemonType* {.pure.} = enum
+        Fire, Psychic # ...
+
+    Charmander* = object
+    Espeon* = object
+
+proc makeNoise*(this: Charmander): string = "Charmander, Charmander"
+proc legs*(this: Charmander): int = 2
+proc greet*(this: Charmander, other: string): string = "Charmander, Char, Charmander... (" & other & ")"
+
+proc makeNoise*(this: Espeon): string = "By using Telepathy I'm able to communicate with creatures of other species"
+proc legs*(this: Espeon): int = 4
+proc greet*(this: Espeon, other: string): string = "What a pleasure to meet you, " & other
+
+createInterface *Pokemon:
+    proc name*(this: Pokemon): string
+    proc typ*(this: Pokemon): PokemonType
+
+proc name*(this: Espeon): string = "Espeon"
+proc typ*(this: Espeon): PokemonType = PokemonType.Psychic
+
+proc name*(this: Charmander): string = "Charmander"
+proc typ*(this: Charmander): PokemonType = PokemonType.Fire

--- a/test_exports.nim
+++ b/test_exports.nim
@@ -26,8 +26,8 @@ proc name*(this: Charmander): string = "Charmander"
 proc typ*(this: Charmander): PokemonType = PokemonType.Fire
 
 createInterface *LogSink:
-  proc log*(this: LogSink, msg: string)
-  proc messagesWritten(this: LogSink): int
+  proc log*(self: LogSink, msg: string)
+  proc messagesWritten(self: LogSink): int
 
 proc echoSinkState*(sink: LogSink) =
   echo sink.messagesWritten()

--- a/test_logsink.nim
+++ b/test_logsink.nim
@@ -5,8 +5,8 @@ import test_exports
 type MyLogSink = object
     messages: seq[string]
 
-proc log(this: var MyLogSink, msg: string) = this.messages.add(msg)
-proc messagesWritten(this: MyLogSink): int = this.messages.len
+proc log(self: var MyLogSink, msg: string) = self.messages.add(msg)
+proc messagesWritten(self: MyLogSink): int = self.messages.len
 
 when isMainModule:
     var myLogSink = MyLogSink(messages: @[])

--- a/test_logsink.nim
+++ b/test_logsink.nim
@@ -1,0 +1,17 @@
+import interfaced
+
+import test_exports
+
+type MyLogSink = object
+    messages: seq[string]
+
+proc log(this: var MyLogSink, msg: string) = this.messages.add(msg)
+proc messagesWritten(this: MyLogSink): int = this.messages.len
+
+when isMainModule:
+    var myLogSink = MyLogSink(messages: @[])
+
+    myLogSink.log("Hello World")
+    myLogSink.log("ABC")
+    
+    echoSinkstate(myLogSink)


### PR DESCRIPTION
I don't know if it was originally broken or not, but in my case, the AST(generated by this piece of code: https://github.com/andreaferretti/interfaced/blob/master/interfaced.nim#L14-L28) was invalid, so I fixed it. 
The interface type can now be exported by adding a `*` before it's name(unfortunately the Nim lexer or parser can't handle a name*: or (name*): that's why I chose to do it this way). Methods need to be exported individually.
By adding a [`mixin` statement to the lambda](), an invalid recursion is fixed which happens sometimes, when an implementation happens after the interface definition(I didn't tested if this only happens only with exported procs).
And at last but not least, I added some documentation and one basic test/example(to test whether implementing a not exported method is possible).

EDIT: I just added that the this parameter doesn't has to be called `this`(e.g. `self` is also popular choice)